### PR TITLE
Use the protocol in use to avoid mixed content warning

### DIFF
--- a/app/controllers/concerns/foreman_cockpit/hosts_controller_extensions.rb
+++ b/app/controllers/concerns/foreman_cockpit/hosts_controller_extensions.rb
@@ -37,7 +37,7 @@ module ForemanCockpit
     end
 
     def cockpit_protocol
-      require_ssl? ? 'https' : 'http'
+      request.ssl? ? 'https' : 'http'
     end
   end
 end


### PR DESCRIPTION
My dev box doesn't require SSL but I was using it, I think it's probably better to look at how the user is currently connected to determine which protocol to use to cockpit.
