### PR TITLE
Cockpit URLs updated

### DIFF
--- a/lib/foreman_cockpit.rb
+++ b/lib/foreman_cockpit.rb
@@ -7,12 +7,12 @@ module ForemanCockpit
                        services networking containers
                        storage accounts)
 
-  COCKPIT_SUBURL = { :system => 'shell/shell.html#/server',
+  COCKPIT_SUBURL = { :system => 'system/index.html',
                      :terminal => 'system/terminal.html',
-                     :journal => 'system/journal.html',
-                     :services => 'system/init.html',
-                     :networking => 'shell/shell.html#/networking',
-                     :containers => 'docker/containers.html',
-                     :storage => 'storage/devices.html',
-                     :accounts => 'shell/shell.html#/accounts' }
+                     :journal => 'system/logs.html',
+                     :services => 'system/services.html',
+                     :networking => 'network/index.html',
+                     :containers => 'docker/index.html',
+                     :storage => 'storage/index.html',
+                     :accounts => 'users/index.html' }
 end


### PR DESCRIPTION
I have updated the Cockpit URLs to match the version available on CentOS 7 (0.77) and Fedora (0.94).

Added no backwards compatibility because the Cockpit project seems to be so fast moving and I did not find when the URLs were changed.
