### PR TITLE
replace alias_method_chain with Module.prepend

### DIFF
--- a/app/helpers/concerns/foreman_cockpit/hosts_helper_extensions.rb
+++ b/app/helpers/concerns/foreman_cockpit/hosts_helper_extensions.rb
@@ -5,13 +5,15 @@ module ForemanCockpit
   module HostsHelperExtensions
     extend ActiveSupport::Concern
 
-    included do
-      alias_method_chain :host_title_actions, :cockpit
+    module Overrides
+      def host_title_actions(*args)
+        create_cockpit_bar if @host.cockpit_enabled?
+        super
+      end
     end
 
-    def host_title_actions_with_cockpit(*args)
-      create_cockpit_bar if @host.cockpit_enabled?
-      host_title_actions_without_cockpit(*args)
+    included do
+      prepend Overrides
     end
 
     private


### PR DESCRIPTION
This plugin conflicts with foreman_monitoring (see https://github.com/theforeman/foreman_monitoring/issues/30) because it still uses `alias_method_chain`. This PR replaces the deprecated `alias_method_chain` with `Module.prepend`.